### PR TITLE
Add slash-command interaction loop

### DIFF
--- a/src/JinPingMei.Game/Hosting/Commands/CommandRouter.cs
+++ b/src/JinPingMei.Game/Hosting/Commands/CommandRouter.cs
@@ -1,0 +1,106 @@
+using System.Collections.Generic;
+using JinPingMei.Game.Localization;
+
+namespace JinPingMei.Game.Hosting.Commands;
+
+public sealed class CommandRouter
+{
+    private readonly Dictionary<string, ICommandHandler> _handlers;
+
+    public CommandRouter(IEnumerable<ICommandHandler> handlers)
+    {
+        _handlers = new Dictionary<string, ICommandHandler>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var handler in handlers)
+        {
+            _handlers[handler.Command] = handler;
+        }
+    }
+
+    public CommandResult Dispatch(string commandText, CommandContext context)
+    {
+        if (context is null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        var trimmed = commandText.Trim();
+        if (string.IsNullOrEmpty(trimmed))
+        {
+            return CommandResult.FromMessage(context.Localize("commands.invalid"));
+        }
+
+        var separatorIndex = trimmed.IndexOf(' ');
+        var commandName = separatorIndex >= 0 ? trimmed[..separatorIndex] : trimmed;
+        var arguments = separatorIndex >= 0 ? trimmed[(separatorIndex + 1)..].Trim() : string.Empty;
+
+        if (_handlers.TryGetValue(commandName, out var handler))
+        {
+            return handler.Handle(context, arguments);
+        }
+
+        return CommandResult.FromMessage(context.Localize("commands.unknown"));
+    }
+
+    public static CommandRouter CreateDefault(ILocalizationProvider localization)
+    {
+        _ = localization ?? throw new ArgumentNullException(nameof(localization));
+
+        var handlers = new ICommandHandler[]
+        {
+            new HelpCommandHandler(),
+            new NameCommandHandler(),
+            new LookCommandHandler(),
+            new SayCommandHandler(),
+            new QuitCommandHandler(),
+        };
+
+        return new CommandRouter(handlers);
+    }
+}
+
+public sealed record CommandResult(IReadOnlyList<string> Lines, bool ShouldDisconnect)
+{
+    public static CommandResult Empty { get; } = new(Array.Empty<string>(), false);
+
+    public static CommandResult FromMessage(string message, bool shouldDisconnect = false)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            return new CommandResult(Array.Empty<string>(), shouldDisconnect);
+        }
+
+        return new CommandResult(new[] { message }, shouldDisconnect);
+    }
+}
+
+public sealed class CommandContext
+{
+    private readonly ILocalizationProvider _localization;
+
+    public CommandContext(SessionState session, ILocalizationProvider localization)
+    {
+        Session = session;
+        _localization = localization;
+    }
+
+    public SessionState Session { get; }
+
+    public string Localize(string key)
+    {
+        return _localization.GetString(Session.Locale, key);
+    }
+
+    public string Format(string key, params object[] arguments)
+    {
+        var value = Localize(key);
+        return string.Format(value, arguments);
+    }
+}
+
+public interface ICommandHandler
+{
+    string Command { get; }
+
+    CommandResult Handle(CommandContext context, string arguments);
+}

--- a/src/JinPingMei.Game/Hosting/Commands/DefaultCommandHandlers.cs
+++ b/src/JinPingMei.Game/Hosting/Commands/DefaultCommandHandlers.cs
@@ -1,0 +1,80 @@
+namespace JinPingMei.Game.Hosting.Commands;
+
+public sealed class HelpCommandHandler : ICommandHandler
+{
+    public string Command => "help";
+
+    public CommandResult Handle(CommandContext context, string arguments)
+    {
+        var lines = new[]
+        {
+            context.Localize("commands.help.summary"),
+            context.Localize("commands.help.detail")
+        };
+
+        return new CommandResult(lines, false);
+    }
+}
+
+public sealed class NameCommandHandler : ICommandHandler
+{
+    private const int MaxNameLength = 32;
+
+    public string Command => "name";
+
+    public CommandResult Handle(CommandContext context, string arguments)
+    {
+        if (string.IsNullOrWhiteSpace(arguments))
+        {
+            return CommandResult.FromMessage(context.Localize("commands.name.prompt"));
+        }
+
+        var trimmed = arguments.Trim();
+        if (trimmed.Length > MaxNameLength)
+        {
+            return CommandResult.FromMessage(context.Format("commands.name.too_long", MaxNameLength));
+        }
+
+        context.Session.PlayerName = trimmed;
+        return CommandResult.FromMessage(context.Format("commands.name.confirm", trimmed));
+    }
+}
+
+public sealed class LookCommandHandler : ICommandHandler
+{
+    public string Command => "look";
+
+    public CommandResult Handle(CommandContext context, string arguments)
+    {
+        return CommandResult.FromMessage(context.Localize("commands.look.description"));
+    }
+}
+
+public sealed class SayCommandHandler : ICommandHandler
+{
+    public string Command => "say";
+
+    public CommandResult Handle(CommandContext context, string arguments)
+    {
+        if (string.IsNullOrWhiteSpace(arguments))
+        {
+            return CommandResult.FromMessage(context.Localize("commands.say.prompt"));
+        }
+
+        var displayName = context.Session.HasPlayerName
+            ? context.Session.PlayerName!
+            : context.Localize("session.display_name.default");
+
+        return CommandResult.FromMessage(context.Format("commands.say.echo", displayName, arguments.Trim()));
+    }
+}
+
+public sealed class QuitCommandHandler : ICommandHandler
+{
+    public string Command => "quit";
+
+    public CommandResult Handle(CommandContext context, string arguments)
+    {
+        return CommandResult.FromMessage(context.Localize("commands.quit.confirm"), shouldDisconnect: true);
+    }
+}

--- a/src/JinPingMei.Game/Hosting/GameSession.cs
+++ b/src/JinPingMei.Game/Hosting/GameSession.cs
@@ -1,33 +1,72 @@
 using JinPingMei.Engine;
+using JinPingMei.Game.Hosting.Commands;
+using JinPingMei.Game.Localization;
 
 namespace JinPingMei.Game.Hosting;
 
 public sealed class GameSession
 {
     private readonly GameRuntime _runtime;
+    private readonly SessionState _state;
+    private readonly ILocalizationProvider _localization;
+    private readonly CommandRouter _commandRouter;
+    private readonly CommandContext _commandContext;
 
-    public GameSession(GameRuntime runtime)
+    public GameSession(GameRuntime runtime, ILocalizationProvider localization)
     {
         _runtime = runtime;
+        _localization = localization;
+        _state = new SessionState { Locale = localization.DefaultLocale };
+        _commandRouter = CommandRouter.CreateDefault(localization);
+        _commandContext = new CommandContext(_state, localization);
     }
+
+    public SessionState State => _state;
 
     public string RenderIntro()
     {
         return _runtime.RenderIntro();
     }
 
-    public string HandleCommand(string command)
+    public string GetCommandHint()
     {
-        if (string.IsNullOrWhiteSpace(command))
+        return _localization.GetString(_state.Locale, "session.commands.hint");
+    }
+
+    public CommandResult HandleInput(string input)
+    {
+        if (string.IsNullOrWhiteSpace(input))
         {
-            return "[WIP] 指令尚未實作。請輸入 'help' 或 'quit'.";
+            return CommandResult.FromMessage(_commandContext.Localize("story.empty"));
         }
 
-        if (string.Equals(command, "help", StringComparison.OrdinalIgnoreCase))
+        if (IsCommand(input))
         {
-            return "Prototype 支援指令: help, quit. 故事互動即將推出。";
+            var commandBody = input[1..];
+            return _commandRouter.Dispatch(commandBody, _commandContext);
         }
 
-        return $"[WIP] 已收到指令：{command}。互動劇情開發中。";
+        return HandleStoryInteraction(input);
+    }
+
+    private CommandResult HandleStoryInteraction(string input)
+    {
+        var trimmed = input.Trim();
+        if (trimmed.Length == 0)
+        {
+            return CommandResult.FromMessage(_commandContext.Localize("story.empty"));
+        }
+
+        var displayName = _state.HasPlayerName
+            ? _state.PlayerName!
+            : _commandContext.Localize("session.display_name.default");
+
+        var response = _commandContext.Format("story.placeholder", displayName, trimmed);
+        return CommandResult.FromMessage(response);
+    }
+
+    private static bool IsCommand(string input)
+    {
+        return input.Length > 0 && input[0] == '/';
     }
 }

--- a/src/JinPingMei.Game/Hosting/GameSessionFactory.cs
+++ b/src/JinPingMei.Game/Hosting/GameSessionFactory.cs
@@ -1,0 +1,20 @@
+using JinPingMei.Engine;
+using JinPingMei.Game.Localization;
+
+namespace JinPingMei.Game.Hosting;
+
+public sealed class GameSessionFactory : IGameSessionFactory
+{
+    private readonly ILocalizationProvider _localization;
+
+    public GameSessionFactory(ILocalizationProvider localization)
+    {
+        _localization = localization;
+    }
+
+    public GameSession Create()
+    {
+        var runtime = GameRuntime.CreateDefault();
+        return new GameSession(runtime, _localization);
+    }
+}

--- a/src/JinPingMei.Game/Hosting/IGameSessionFactory.cs
+++ b/src/JinPingMei.Game/Hosting/IGameSessionFactory.cs
@@ -1,0 +1,6 @@
+namespace JinPingMei.Game.Hosting;
+
+public interface IGameSessionFactory
+{
+    GameSession Create();
+}

--- a/src/JinPingMei.Game/Hosting/SessionState.cs
+++ b/src/JinPingMei.Game/Hosting/SessionState.cs
@@ -1,0 +1,10 @@
+namespace JinPingMei.Game.Hosting;
+
+public sealed class SessionState
+{
+    public string Locale { get; set; } = "zh-TW";
+
+    public string? PlayerName { get; set; }
+
+    public bool HasPlayerName => !string.IsNullOrWhiteSpace(PlayerName);
+}

--- a/src/JinPingMei.Game/Hosting/TelnetGameServer.cs
+++ b/src/JinPingMei.Game/Hosting/TelnetGameServer.cs
@@ -8,6 +8,8 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using JinPingMei.Engine;
+using JinPingMei.Game.Hosting.Commands;
+using JinPingMei.Game.Localization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -21,6 +23,7 @@ public sealed class TelnetGameServer
     private readonly TelnetGameServerOptions _options;
     private readonly ILogger<TelnetGameServer> _logger;
     private readonly ITelnetServerMetrics _metrics;
+    private readonly IGameSessionFactory _sessionFactory;
     private TcpListener? _listener;
     private readonly List<Task> _clientTasks = new();
     private readonly object _sync = new();
@@ -31,12 +34,14 @@ public sealed class TelnetGameServer
         IPEndPoint endpoint,
         TelnetGameServerOptions? options = null,
         ILogger<TelnetGameServer>? logger = null,
-        ITelnetServerMetrics? metrics = null)
+        ITelnetServerMetrics? metrics = null,
+        IGameSessionFactory? sessionFactory = null)
     {
         _endpoint = endpoint;
         _options = options ?? new TelnetGameServerOptions();
         _logger = logger ?? NullLogger<TelnetGameServer>.Instance;
         _metrics = metrics ?? new NullTelnetServerMetrics();
+        _sessionFactory = sessionFactory ?? CreateDefaultSessionFactory();
 
         if (_options.MaxConcurrentSessions <= 0)
         {
@@ -147,12 +152,13 @@ public sealed class TelnetGameServer
                 NewLine = "\r\n"
             };
 
-            var session = new GameSession(GameRuntime.CreateDefault());
+            var session = _sessionFactory.Create();
 
             await writer.WriteLineAsync("歡迎來到《金瓶梅》互動敘事實驗。");
-            await writer.WriteLineAsync(" Type 'help' for prototype commands. Type 'quit' to disconnect.");
+            await writer.WriteLineAsync(" 輸入 '/help' 查看指令清單，輸入 '/quit' 離線。");
             await writer.WriteLineAsync(string.Empty);
             await writer.WriteLineAsync(session.RenderIntro());
+            await writer.WriteLineAsync(session.GetCommandHint());
 
             if (sessionActivity is not null)
             {
@@ -209,30 +215,27 @@ public sealed class TelnetGameServer
 
                         var trimmed = line.Trim();
 
-                        if (trimmed.Equals("quit", StringComparison.OrdinalIgnoreCase))
-                        {
-                            using var exitActivity = StartChildActivity("telnet.session.client_exit", sessionContext);
-                            exitActivity?.SetTag("telnet.command", trimmed);
-                            exitActivity?.SetStatus(ActivityStatusCode.Ok);
-                            await writer.WriteLineAsync("再見，期待下次相會。");
-                            return;
-                        }
-
                         using var commandActivity = StartChildActivity("telnet.command", sessionContext);
                         if (commandActivity is not null)
                         {
                             commandActivity.SetTag("telnet.command", trimmed);
                         }
 
-                        var response = session.HandleCommand(trimmed);
-                        var responseLength = response?.Length ?? 0;
-                        commandActivity?.SetTag("telnet.response.length", responseLength);
-                        commandActivity?.AddEvent(new ActivityEvent("command_processed", tags: new ActivityTagsCollection
+                        var commandResult = session.HandleInput(trimmed);
+                        WriteCommandTelemetry(commandActivity, commandResult, trimmed);
+
+                        foreach (var responseLine in commandResult.Lines)
                         {
-                            { "telnet.command", trimmed },
-                            { "telnet.response.length", responseLength }
-                        }));
-                        await writer.WriteLineAsync(response);
+                            await writer.WriteLineAsync(responseLine);
+                        }
+
+                        if (commandResult.ShouldDisconnect)
+                        {
+                            using var exitActivity = StartChildActivity("telnet.session.client_exit", sessionContext);
+                            exitActivity?.SetTag("telnet.command", trimmed);
+                            exitActivity?.SetStatus(ActivityStatusCode.Ok);
+                            return;
+                        }
                         break;
                     }
 
@@ -488,6 +491,36 @@ public sealed class TelnetGameServer
             { "exception.message", exception.Message },
             { "exception.stacktrace", exception.StackTrace ?? string.Empty }
         }));
+    }
+
+    private static IGameSessionFactory CreateDefaultSessionFactory()
+    {
+        var localizationPath = Path.Combine(AppContext.BaseDirectory, "Localization");
+        var localizationProvider = new JsonLocalizationProvider(localizationPath);
+        return new GameSessionFactory(localizationProvider);
+    }
+
+    private static void WriteCommandTelemetry(Activity? activity, CommandResult result, string input)
+    {
+        if (activity is null)
+        {
+            return;
+        }
+
+        var isCommand = input.StartsWith('/');
+        activity.SetTag("telnet.input.raw", input);
+        activity.SetTag("telnet.input.type", isCommand ? "command" : "story");
+
+        var totalLength = 0;
+        foreach (var line in result.Lines)
+        {
+            totalLength += line?.Length ?? 0;
+        }
+
+        activity.SetTag("telnet.response.line_count", result.Lines.Count);
+        activity.SetTag("telnet.response.length", totalLength);
+        activity.SetTag("telnet.session.disconnect", result.ShouldDisconnect);
+        activity.SetStatus(ActivityStatusCode.Ok);
     }
 
     private static IPEndPoint? TryGetRemoteEndPoint(TcpClient client, out string? display)

--- a/src/JinPingMei.Game/JinPingMei.Game.csproj
+++ b/src/JinPingMei.Game/JinPingMei.Game.csproj
@@ -29,6 +29,9 @@
     <None Update="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Localization\**\*.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/src/JinPingMei.Game/Localization/ILocalizationProvider.cs
+++ b/src/JinPingMei.Game/Localization/ILocalizationProvider.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace JinPingMei.Game.Localization;
+
+public interface ILocalizationProvider
+{
+    string DefaultLocale { get; }
+
+    string GetString(string locale, string key);
+
+    IReadOnlyDictionary<string, string> GetLocaleCatalog(string locale);
+}

--- a/src/JinPingMei.Game/Localization/JsonLocalizationProvider.cs
+++ b/src/JinPingMei.Game/Localization/JsonLocalizationProvider.cs
@@ -1,0 +1,95 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+
+namespace JinPingMei.Game.Localization;
+
+public sealed class JsonLocalizationProvider : ILocalizationProvider
+{
+    private readonly ConcurrentDictionary<string, IReadOnlyDictionary<string, string>> _catalogs = new(StringComparer.OrdinalIgnoreCase);
+    private readonly string _basePath;
+
+    public JsonLocalizationProvider(string basePath, string defaultLocale = "zh-TW")
+    {
+        if (string.IsNullOrWhiteSpace(basePath))
+        {
+            throw new ArgumentException("Base path must be provided", nameof(basePath));
+        }
+
+        if (!Directory.Exists(basePath))
+        {
+            throw new DirectoryNotFoundException($"Localization directory not found: {basePath}");
+        }
+
+        _basePath = basePath;
+        DefaultLocale = defaultLocale;
+    }
+
+    public string DefaultLocale { get; }
+
+    public string GetString(string locale, string key)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            return string.Empty;
+        }
+
+        var localeCatalog = GetLocaleCatalog(locale);
+        if (localeCatalog.TryGetValue(key, out var value))
+        {
+            return value;
+        }
+
+        if (!string.Equals(locale, DefaultLocale, StringComparison.OrdinalIgnoreCase))
+        {
+            var fallbackCatalog = GetLocaleCatalog(DefaultLocale);
+            if (fallbackCatalog.TryGetValue(key, out var fallbackValue))
+            {
+                return fallbackValue;
+            }
+        }
+
+        return key;
+    }
+
+    public IReadOnlyDictionary<string, string> GetLocaleCatalog(string locale)
+    {
+        var normalizedLocale = string.IsNullOrWhiteSpace(locale) ? DefaultLocale : locale;
+
+        return _catalogs.GetOrAdd(normalizedLocale, LoadLocale);
+    }
+
+    private IReadOnlyDictionary<string, string> LoadLocale(string locale)
+    {
+        var localePath = Path.Combine(_basePath, locale);
+        if (!Directory.Exists(localePath))
+        {
+            return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var file in Directory.EnumerateFiles(localePath, "*.json", SearchOption.AllDirectories))
+        {
+            using var stream = File.OpenRead(file);
+            var document = JsonDocument.Parse(stream);
+
+            if (document.RootElement.ValueKind != JsonValueKind.Object)
+            {
+                continue;
+            }
+
+            foreach (var property in document.RootElement.EnumerateObject())
+            {
+                var value = property.Value.ValueKind switch
+                {
+                    JsonValueKind.String => property.Value.GetString() ?? string.Empty,
+                    _ => property.Value.ToString()
+                };
+
+                result[property.Name] = value;
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/JinPingMei.Game/Localization/zh-TW/commands.json
+++ b/src/JinPingMei.Game/Localization/zh-TW/commands.json
@@ -1,0 +1,17 @@
+{
+  "commands.invalid": "請輸入要執行的指令，例如 /help。",
+  "commands.unknown": "無法識別這個指令。輸入 /help 查看可用清單。",
+  "commands.help.summary": "目前可用指令：/help、/name <名字>、/look、/say <內容>、/quit。",
+  "commands.help.detail": "所有系統指令都以 / 開頭；其他內容則會交給故事互動。",
+  "commands.name.prompt": "請輸入 /name 後接您的名字，例如 /name 西門慶。",
+  "commands.name.too_long": "名字最長 {0} 個字元，請再試一次。",
+  "commands.name.confirm": "好的，從現在起我們將以「{0}」稱呼您。",
+  "commands.look.description": "您打量四周，這裡仍在搭建中，等待著未來的戲劇被喚醒。",
+  "commands.say.prompt": "請在 /say 後輸入想說的話，例如 /say 今日風甚暖。",
+  "commands.say.echo": "{0}說：「{1}」",
+  "commands.quit.confirm": "感謝體驗，期待下次再會。",
+  "session.display_name.default": "旅人",
+  "session.commands.hint": "輸入 /help 查看可用指令；其餘文字會用於故事互動。",
+  "story.empty": "你靜靜地沉默著。",
+  "story.placeholder": "{0}的話語尚未觸發劇情，請稍後再試：「{1}」。"
+}

--- a/src/JinPingMei.Game/Program.cs
+++ b/src/JinPingMei.Game/Program.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using JinPingMei.Game.Hosting;
+using JinPingMei.Game.Localization;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using dotenv.net;
@@ -37,9 +38,11 @@ using var loggerFactory = LoggerFactory.Create(static builder =>
 using var tracerProvider = BuildTracerProvider(configuration);
 using var meterProvider = BuildMeterProvider(configuration);
 using var metrics = new TelnetServerMetrics();
+var localizationProvider = BuildLocalizationProvider();
+var sessionFactory = new GameSessionFactory(localizationProvider);
 
 var endpoint = hostSettings.ToEndpoint();
-var server = new TelnetGameServer(endpoint, options, loggerFactory.CreateLogger<TelnetGameServer>(), metrics);
+var server = new TelnetGameServer(endpoint, options, loggerFactory.CreateLogger<TelnetGameServer>(), metrics, sessionFactory);
 
 using var cts = new CancellationTokenSource();
 
@@ -188,4 +191,10 @@ static void LoadEnvFiles()
 
         DotEnv.Load(new DotEnvOptions(envFilePaths: new[] { path }, overwriteExistingVars: true, ignoreExceptions: true));
     }
+}
+
+static JsonLocalizationProvider BuildLocalizationProvider()
+{
+    var localizationPath = Path.Combine(AppContext.BaseDirectory, "Localization");
+    return new JsonLocalizationProvider(localizationPath);
 }

--- a/tests/JinPingMei.Engine.Tests/GameSessionTests.cs
+++ b/tests/JinPingMei.Engine.Tests/GameSessionTests.cs
@@ -1,29 +1,71 @@
+using System.Linq;
 using JinPingMei.Game.Hosting;
+using JinPingMei.Game.Localization;
+using JinPingMei.Engine;
 
 namespace JinPingMei.Engine.Tests;
 
 public class GameSessionTests
 {
-    [Theory]
-    [InlineData("")]
-    [InlineData(null)]
-    [InlineData("   ")]
-    public void HandleCommand_EmptyOrWhitespace_ReturnsPlaceholder(string? input)
+    private readonly ILocalizationProvider _localization = new TestLocalizationProvider();
+
+    [Fact]
+    public void HandleInput_NameCommand_SetsPlayerName()
     {
-        var session = new GameSession(GameRuntime.CreateDefault());
+        var session = CreateSession();
 
-        var response = session.HandleCommand(input ?? string.Empty);
+        var result = session.HandleInput("/name 西門慶");
 
-        Assert.Contains("指令尚未實作", response);
+        Assert.Equal("西門慶", session.State.PlayerName);
+        Assert.Contains("西門慶", result.Lines.Single());
     }
 
     [Fact]
-    public void HandleCommand_Help_ReturnsHelpText()
+    public void HandleInput_SayWithoutName_UsesDefaultDisplayName()
     {
-        var session = new GameSession(GameRuntime.CreateDefault());
+        var session = CreateSession();
 
-        var response = session.HandleCommand("help");
+        var result = session.HandleInput("/say 我在此聆聽。");
 
-        Assert.Contains("Prototype", response);
+        Assert.Single(result.Lines);
+        Assert.Contains(_localization.GetString("zh-TW", "session.display_name.default"), result.Lines.Single());
+    }
+
+    [Fact]
+    public void HandleInput_FreeText_ProducesPlaceholderNarration()
+    {
+        var session = CreateSession();
+        session.HandleInput("/name 金蓮");
+
+        var result = session.HandleInput("我望向窗外的月色。");
+
+        Assert.Single(result.Lines);
+        Assert.Contains("金蓮", result.Lines.Single());
+    }
+
+    [Fact]
+    public void HandleInput_QuitCommand_RequestsDisconnect()
+    {
+        var session = CreateSession();
+
+        var result = session.HandleInput("/quit");
+
+        Assert.True(result.ShouldDisconnect);
+    }
+
+    [Fact]
+    public void HandleInput_UnknownCommand_ReturnsLocalizedMessage()
+    {
+        var session = CreateSession();
+
+        var result = session.HandleInput("/dance");
+
+        Assert.Contains("無法識別", result.Lines.Single());
+    }
+
+    private GameSession CreateSession()
+    {
+        var runtime = GameRuntime.CreateDefault();
+        return new GameSession(runtime, _localization);
     }
 }

--- a/tests/JinPingMei.Engine.Tests/TestLocalizationProvider.cs
+++ b/tests/JinPingMei.Engine.Tests/TestLocalizationProvider.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using JinPingMei.Game.Localization;
+
+namespace JinPingMei.Engine.Tests;
+
+internal sealed class TestLocalizationProvider : ILocalizationProvider
+{
+    private readonly Dictionary<string, IReadOnlyDictionary<string, string>> _catalogs;
+
+    public TestLocalizationProvider()
+    {
+        var zhTw = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["commands.invalid"] = "請輸入要執行的指令，例如 /help。",
+            ["commands.unknown"] = "無法識別這個指令。",
+            ["commands.help.summary"] = "目前可用指令：/help、/name <名字>、/look、/say <內容>、/quit。",
+            ["commands.help.detail"] = "所有系統指令都以 / 開頭；其他內容則會交給故事互動。",
+            ["commands.name.prompt"] = "請輸入 /name 後接您的名字。",
+            ["commands.name.too_long"] = "名字最長 {0} 個字元。",
+            ["commands.name.confirm"] = "從現在起我們將以「{0}」稱呼您。",
+            ["commands.look.description"] = "仍在搭建中的場景。",
+            ["commands.say.prompt"] = "請在 /say 後輸入想說的話。",
+            ["commands.say.echo"] = "{0}說：「{1}」",
+            ["commands.quit.confirm"] = "期待下次再會。",
+            ["session.display_name.default"] = "旅人",
+            ["session.commands.hint"] = "輸入 /help 查看可用指令；其餘文字會用於故事互動。",
+            ["story.empty"] = "你靜靜地沉默著。",
+            ["story.placeholder"] = "{0}的話語尚未觸發劇情：「{1}」。"
+        };
+
+        _catalogs = new Dictionary<string, IReadOnlyDictionary<string, string>>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["zh-TW"] = zhTw
+        };
+    }
+
+    public string DefaultLocale => "zh-TW";
+
+    public string GetString(string locale, string key)
+    {
+        var catalog = GetLocaleCatalog(locale);
+        return catalog.TryGetValue(key, out var value)
+            ? value
+            : key;
+    }
+
+    public IReadOnlyDictionary<string, string> GetLocaleCatalog(string locale)
+    {
+        return _catalogs.TryGetValue(locale, out var value)
+            ? value
+            : _catalogs[DefaultLocale];
+    }
+}


### PR DESCRIPTION
## Summary
- introduce session-scoped command router with slash-prefixed commands routed to modular handlers
- add JSON-backed localization provider and zh-TW command copy for help/name/look/say/quit
- wire telnet server to use new session factory, emit command hints, and keep free-text narration path
- cover command behaviours with new unit tests and update telnet server tests for slash flow

Resolves #2

## Testing
- dotnet test JinPingMei.sln