### PR TITLE
Add telnet observability diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,3 +47,7 @@
 ## Security & Configuration Notes
 - Do not commit API keys; load provider tokens via environment variables (`.env` is ignored by default).
 - Sensitive source texts remain in `data/`; avoid exporting or publishing them without confirming licensing obligations.
+
+## Agent Workflow Notes
+- Before running integration smoke tests, stop any existing processes holding the telnet testing ports to avoid `Address already in use` errors.
+- Run long-lived commands (for example `dotnet run`, `npm run dev`) in a separate shell or launch them in the background so they never block other automation steps.

--- a/src/JinPingMei.Game/Hosting/Commands/AdminCommandHandlers.cs
+++ b/src/JinPingMei.Game/Hosting/Commands/AdminCommandHandlers.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+
+namespace JinPingMei.Game.Hosting.Commands;
+
+public sealed class DiagnosticsCommandHandler : ICommandHandler
+{
+    private readonly ITelnetServerDiagnostics _diagnostics;
+
+    public DiagnosticsCommandHandler(ITelnetServerDiagnostics diagnostics)
+    {
+        _diagnostics = diagnostics ?? throw new ArgumentNullException(nameof(diagnostics));
+    }
+
+    public string Command => "diagnostics";
+
+    public CommandResult Handle(CommandContext context, string arguments)
+    {
+        var snapshot = _diagnostics.CaptureSnapshot();
+        var uptime = FormatDuration(snapshot.Uptime);
+
+        var lines = new List<string>
+        {
+            context.Localize("commands.diagnostics.header"),
+            context.Format("commands.diagnostics.uptime", uptime),
+            context.Format("commands.diagnostics.sessions.active", snapshot.ActiveSessions),
+            context.Format("commands.diagnostics.sessions.total", snapshot.TotalSessions, snapshot.RejectedSessions),
+            context.Format("commands.diagnostics.sessions.completed", snapshot.CompletedSessions),
+            context.Format("commands.diagnostics.errors", snapshot.TotalErrors, snapshot.SessionErrors, snapshot.CommandErrors),
+            context.Format("commands.diagnostics.commands", snapshot.TotalCommands, snapshot.SessionsPerMinute)
+        };
+
+        return new CommandResult(lines, false);
+    }
+
+    private static string FormatDuration(TimeSpan uptime)
+    {
+        if (uptime.TotalSeconds < 1)
+        {
+            return "<1 秒";
+        }
+
+        if (uptime.TotalMinutes < 1)
+        {
+            return string.Format("{0:F0} 秒", uptime.TotalSeconds);
+        }
+
+        if (uptime.TotalHours < 1)
+        {
+            return string.Format("{0:F1} 分鐘", uptime.TotalMinutes);
+        }
+
+        if (uptime.TotalDays < 1)
+        {
+            return string.Format("{0:F1} 小時", uptime.TotalHours);
+        }
+
+        return string.Format("{0:F1} 天", uptime.TotalDays);
+    }
+}
+
+public sealed class HealthCommandHandler : ICommandHandler
+{
+    private readonly ITelnetServerDiagnostics _diagnostics;
+
+    public HealthCommandHandler(ITelnetServerDiagnostics diagnostics)
+    {
+        _diagnostics = diagnostics ?? throw new ArgumentNullException(nameof(diagnostics));
+    }
+
+    public string Command => "health";
+
+    public CommandResult Handle(CommandContext context, string arguments)
+    {
+        var snapshot = _diagnostics.CaptureSnapshot();
+        var severity = snapshot.TotalErrors > 0
+            ? context.Format("commands.health.degraded", snapshot.TotalErrors)
+            : context.Localize("commands.health.ok");
+
+        var lines = new List<string>
+        {
+            severity,
+            context.Format("commands.health.active", snapshot.ActiveSessions),
+            context.Format("commands.health.started", snapshot.StartedAt.ToLocalTime())
+        };
+
+        return new CommandResult(lines, false);
+    }
+}

--- a/src/JinPingMei.Game/Hosting/GameSession.cs
+++ b/src/JinPingMei.Game/Hosting/GameSession.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using JinPingMei.Engine;
 using JinPingMei.Game.Hosting.Commands;
 using JinPingMei.Game.Localization;
@@ -12,13 +14,14 @@ public sealed class GameSession
     private readonly CommandRouter _commandRouter;
     private readonly CommandContext _commandContext;
 
-    public GameSession(GameRuntime runtime, ILocalizationProvider localization)
+    public GameSession(GameRuntime runtime, ILocalizationProvider localization, ITelnetServerDiagnostics diagnostics, IEnumerable<ICommandHandler>? additionalHandlers = null)
     {
-        _runtime = runtime;
-        _localization = localization;
+        _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
+        _localization = localization ?? throw new ArgumentNullException(nameof(localization));
+        _ = diagnostics ?? throw new ArgumentNullException(nameof(diagnostics));
         _state = new SessionState { Locale = localization.DefaultLocale };
-        _commandRouter = CommandRouter.CreateDefault(localization);
-        _commandContext = new CommandContext(_state, localization);
+        _commandRouter = CommandRouter.CreateDefault(localization, diagnostics, additionalHandlers);
+        _commandContext = new CommandContext(_state, localization, diagnostics);
     }
 
     public SessionState State => _state;

--- a/src/JinPingMei.Game/Hosting/GameSessionFactory.cs
+++ b/src/JinPingMei.Game/Hosting/GameSessionFactory.cs
@@ -1,3 +1,4 @@
+using System;
 using JinPingMei.Engine;
 using JinPingMei.Game.Localization;
 
@@ -6,15 +7,17 @@ namespace JinPingMei.Game.Hosting;
 public sealed class GameSessionFactory : IGameSessionFactory
 {
     private readonly ILocalizationProvider _localization;
+    private readonly ITelnetServerDiagnostics _diagnostics;
 
-    public GameSessionFactory(ILocalizationProvider localization)
+    public GameSessionFactory(ILocalizationProvider localization, ITelnetServerDiagnostics diagnostics)
     {
-        _localization = localization;
+        _localization = localization ?? throw new ArgumentNullException(nameof(localization));
+        _diagnostics = diagnostics ?? throw new ArgumentNullException(nameof(diagnostics));
     }
 
     public GameSession Create()
     {
         var runtime = GameRuntime.CreateDefault();
-        return new GameSession(runtime, _localization);
+        return new GameSession(runtime, _localization, _diagnostics);
     }
 }

--- a/src/JinPingMei.Game/Hosting/ITelnetServerDiagnostics.cs
+++ b/src/JinPingMei.Game/Hosting/ITelnetServerDiagnostics.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace JinPingMei.Game.Hosting;
+
+public interface ITelnetServerDiagnostics
+{
+    TelnetServerSnapshot CaptureSnapshot();
+}
+
+public readonly record struct TelnetServerSnapshot(
+    DateTimeOffset StartedAt,
+    TimeSpan Uptime,
+    long ActiveSessions,
+    long TotalSessions,
+    long CompletedSessions,
+    long RejectedSessions,
+    long SessionErrors,
+    long CommandErrors,
+    long InactivityTimeouts,
+    long LifetimeEnforcements,
+    long TotalCommands)
+{
+    public double SessionsPerMinute => Uptime.TotalMinutes > 0
+        ? TotalSessions / Uptime.TotalMinutes
+        : TotalSessions;
+
+    public long TotalErrors => SessionErrors + CommandErrors;
+}

--- a/src/JinPingMei.Game/Hosting/ITelnetServerMetrics.cs
+++ b/src/JinPingMei.Game/Hosting/ITelnetServerMetrics.cs
@@ -1,9 +1,13 @@
+using System;
+
 namespace JinPingMei.Game.Hosting;
 
 public interface ITelnetServerMetrics
 {
     void RecordAccepted();
+    void RecordSessionEnded(bool faulted);
     void RecordRejected();
     void RecordInactivityTimeout();
     void RecordLifetimeLimit();
+    void RecordCommand(TimeSpan duration, bool faulted);
 }

--- a/src/JinPingMei.Game/Hosting/TelnetServerEventSource.cs
+++ b/src/JinPingMei.Game/Hosting/TelnetServerEventSource.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Diagnostics.Tracing;
+
+namespace JinPingMei.Game.Hosting;
+
+[EventSource(Name = "JinPingMei.Game.Hosting.TelnetServer")]
+public sealed class TelnetServerEventSource : EventSource
+{
+    public static TelnetServerEventSource Log { get; } = new();
+
+    private PollingCounter? _activeSessions;
+    private EventCounter? _commandLatency;
+    private Func<double>? _activeSessionsProvider;
+    private bool _initialized;
+
+    private TelnetServerEventSource()
+    {
+    }
+
+    public void Initialize(Func<double> activeSessionsProvider)
+    {
+        // EventSource may be reused across tests; guard against duplicate initialization.
+        if (_initialized)
+        {
+            _activeSessionsProvider = activeSessionsProvider;
+            return;
+        }
+
+        _activeSessionsProvider = activeSessionsProvider;
+        _activeSessions = new PollingCounter("active-sessions", this, () => _activeSessionsProvider?.Invoke() ?? 0);
+        _commandLatency = new EventCounter("command-latency", this)
+        {
+            DisplayName = "Command Latency",
+            DisplayUnits = "ms"
+        };
+
+        _initialized = true;
+    }
+
+    public void ReportCommandLatency(TimeSpan elapsed)
+    {
+        _commandLatency?.WriteMetric((float)elapsed.TotalMilliseconds);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _activeSessions?.Dispose();
+            _commandLatency?.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+}

--- a/src/JinPingMei.Game/Hosting/TelnetServerMetrics.cs
+++ b/src/JinPingMei.Game/Hosting/TelnetServerMetrics.cs
@@ -1,8 +1,11 @@
+using System;
+using System.Diagnostics;
 using System.Diagnostics.Metrics;
+using System.Threading;
 
 namespace JinPingMei.Game.Hosting;
 
-public sealed class TelnetServerMetrics : ITelnetServerMetrics, IDisposable
+public sealed class TelnetServerMetrics : ITelnetServerMetrics, ITelnetServerDiagnostics, IDisposable
 {
     public const string MeterName = "JinPingMei.Game";
     public const string MeterVersion = "1.0";
@@ -13,15 +16,96 @@ public sealed class TelnetServerMetrics : ITelnetServerMetrics, IDisposable
     private readonly Counter<long> _sessionsRejected = Meter.CreateCounter<long>("telnet.sessions.rejected");
     private readonly Counter<long> _sessionsInactiveTimeout = Meter.CreateCounter<long>("telnet.sessions.inactive_timeouts");
     private readonly Counter<long> _sessionsLifetimeLimit = Meter.CreateCounter<long>("telnet.sessions.lifetime_ended");
+    private readonly Histogram<double> _commandLatency = Meter.CreateHistogram<double>("telnet.command.latency", unit: "ms");
+
+    private readonly TelnetServerEventSource _eventSource = TelnetServerEventSource.Log;
+    private readonly DateTimeOffset _startedAt = DateTimeOffset.UtcNow;
+
+    private long _activeSessions;
+    private long _totalSessions;
+    private long _completedSessions;
+    private long _rejectedSessions;
+    private long _sessionErrors;
+    private long _commandErrors;
+    private long _inactivityTimeouts;
+    private long _lifetimeEnforcements;
+    private long _totalCommands;
     private bool _disposed;
 
-    public void RecordAccepted() => _sessionsAccepted.Add(1);
+    public TelnetServerMetrics()
+    {
+        _eventSource.Initialize(() => Volatile.Read(ref _activeSessions));
+    }
 
-    public void RecordRejected() => _sessionsRejected.Add(1);
+    public void RecordAccepted()
+    {
+        _sessionsAccepted.Add(1);
+        Interlocked.Increment(ref _activeSessions);
+        Interlocked.Increment(ref _totalSessions);
+    }
 
-    public void RecordInactivityTimeout() => _sessionsInactiveTimeout.Add(1);
+    public void RecordSessionEnded(bool faulted)
+    {
+        Interlocked.Decrement(ref _activeSessions);
+        Interlocked.Increment(ref _completedSessions);
 
-    public void RecordLifetimeLimit() => _sessionsLifetimeLimit.Add(1);
+        if (faulted)
+        {
+            Interlocked.Increment(ref _sessionErrors);
+        }
+    }
+
+    public void RecordRejected()
+    {
+        _sessionsRejected.Add(1);
+        Interlocked.Increment(ref _rejectedSessions);
+    }
+
+    public void RecordInactivityTimeout()
+    {
+        _sessionsInactiveTimeout.Add(1);
+        Interlocked.Increment(ref _inactivityTimeouts);
+        Interlocked.Increment(ref _sessionErrors);
+    }
+
+    public void RecordLifetimeLimit()
+    {
+        _sessionsLifetimeLimit.Add(1);
+        Interlocked.Increment(ref _lifetimeEnforcements);
+        Interlocked.Increment(ref _sessionErrors);
+    }
+
+    public void RecordCommand(TimeSpan duration, bool faulted)
+    {
+        _commandLatency.Record(duration.TotalMilliseconds);
+        _eventSource.ReportCommandLatency(duration);
+
+        Interlocked.Increment(ref _totalCommands);
+
+        if (faulted)
+        {
+            Interlocked.Increment(ref _commandErrors);
+        }
+    }
+
+    public TelnetServerSnapshot CaptureSnapshot()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var uptime = now - _startedAt;
+
+        return new TelnetServerSnapshot(
+            _startedAt,
+            uptime,
+            Volatile.Read(ref _activeSessions),
+            Volatile.Read(ref _totalSessions),
+            Volatile.Read(ref _completedSessions),
+            Volatile.Read(ref _rejectedSessions),
+            Volatile.Read(ref _sessionErrors),
+            Volatile.Read(ref _commandErrors),
+            Volatile.Read(ref _inactivityTimeouts),
+            Volatile.Read(ref _lifetimeEnforcements),
+            Volatile.Read(ref _totalCommands));
+    }
 
     public void Dispose()
     {

--- a/src/JinPingMei.Game/Localization/zh-TW/commands.json
+++ b/src/JinPingMei.Game/Localization/zh-TW/commands.json
@@ -1,7 +1,7 @@
 {
   "commands.invalid": "請輸入要執行的指令，例如 /help。",
   "commands.unknown": "無法識別這個指令。輸入 /help 查看可用清單。",
-  "commands.help.summary": "目前可用指令：/help、/name <名字>、/look、/say <內容>、/quit。",
+  "commands.help.summary": "目前可用指令：/help、/name <名字>、/look、/say <內容>、/diagnostics、/health、/quit。",
   "commands.help.detail": "所有系統指令都以 / 開頭；其他內容則會交給故事互動。",
   "commands.name.prompt": "請輸入 /name 後接您的名字，例如 /name 西門慶。",
   "commands.name.too_long": "名字最長 {0} 個字元，請再試一次。",
@@ -13,5 +13,16 @@
   "session.display_name.default": "旅人",
   "session.commands.hint": "輸入 /help 查看可用指令；其餘文字會用於故事互動。",
   "story.empty": "你靜靜地沉默著。",
-  "story.placeholder": "{0}的話語尚未觸發劇情，請稍後再試：「{1}」。"
+  "story.placeholder": "{0}的話語尚未觸發劇情，請稍後再試：「{1}」。",
+  "commands.diagnostics.header": "系統診斷資訊：",
+  "commands.diagnostics.uptime": "伺服器已連續執行 {0}。",
+  "commands.diagnostics.sessions.active": "目前連線數：{0}。",
+  "commands.diagnostics.sessions.total": "累計連線：{0}，遭拒：{1}。",
+  "commands.diagnostics.sessions.completed": "已結束連線：{0}。",
+  "commands.diagnostics.errors": "錯誤總數：{0}（會話 {1}、指令 {2}）。",
+  "commands.diagnostics.commands": "指令執行次數：{0}（每分鐘約 {1:F2} 次）。",
+  "commands.health.ok": "系統狀態：正常。",
+  "commands.health.degraded": "系統狀態：注意，目前累計錯誤 {0} 次。",
+  "commands.health.active": "當前連線數：{0}。",
+  "commands.health.started": "啟動時間：{0:yyyy/MM/dd HH:mm:ss}。"
 }

--- a/src/JinPingMei.Game/Program.cs
+++ b/src/JinPingMei.Game/Program.cs
@@ -39,7 +39,7 @@ using var tracerProvider = BuildTracerProvider(configuration);
 using var meterProvider = BuildMeterProvider(configuration);
 using var metrics = new TelnetServerMetrics();
 var localizationProvider = BuildLocalizationProvider();
-var sessionFactory = new GameSessionFactory(localizationProvider);
+var sessionFactory = new GameSessionFactory(localizationProvider, metrics);
 
 var endpoint = hostSettings.ToEndpoint();
 var server = new TelnetGameServer(endpoint, options, loggerFactory.CreateLogger<TelnetGameServer>(), metrics, sessionFactory);

--- a/tests/JinPingMei.Engine.Tests/TestLocalizationProvider.cs
+++ b/tests/JinPingMei.Engine.Tests/TestLocalizationProvider.cs
@@ -13,7 +13,7 @@ internal sealed class TestLocalizationProvider : ILocalizationProvider
         {
             ["commands.invalid"] = "請輸入要執行的指令，例如 /help。",
             ["commands.unknown"] = "無法識別這個指令。",
-            ["commands.help.summary"] = "目前可用指令：/help、/name <名字>、/look、/say <內容>、/quit。",
+            ["commands.help.summary"] = "目前可用指令：/help、/name <名字>、/look、/say <內容>、/diagnostics、/health、/quit。",
             ["commands.help.detail"] = "所有系統指令都以 / 開頭；其他內容則會交給故事互動。",
             ["commands.name.prompt"] = "請輸入 /name 後接您的名字。",
             ["commands.name.too_long"] = "名字最長 {0} 個字元。",
@@ -25,7 +25,18 @@ internal sealed class TestLocalizationProvider : ILocalizationProvider
             ["session.display_name.default"] = "旅人",
             ["session.commands.hint"] = "輸入 /help 查看可用指令；其餘文字會用於故事互動。",
             ["story.empty"] = "你靜靜地沉默著。",
-            ["story.placeholder"] = "{0}的話語尚未觸發劇情：「{1}」。"
+            ["story.placeholder"] = "{0}的話語尚未觸發劇情：「{1}」。",
+            ["commands.diagnostics.header"] = "系統診斷資訊：",
+            ["commands.diagnostics.uptime"] = "伺服器已連續執行 {0}。",
+            ["commands.diagnostics.sessions.active"] = "目前連線數：{0}。",
+            ["commands.diagnostics.sessions.total"] = "累計連線：{0}，遭拒：{1}。",
+            ["commands.diagnostics.sessions.completed"] = "已結束連線：{0}。",
+            ["commands.diagnostics.errors"] = "錯誤總數：{0}（會話 {1}、指令 {2}）。",
+            ["commands.diagnostics.commands"] = "指令執行次數：{0}（每分鐘約 {1:F2} 次）。",
+            ["commands.health.ok"] = "系統狀態：正常。",
+            ["commands.health.degraded"] = "系統狀態：注意，目前累計錯誤 {0} 次。",
+            ["commands.health.active"] = "當前連線數：{0}。",
+            ["commands.health.started"] = "啟動時間：{0:yyyy/MM/dd HH:mm:ss}。"
         };
 
         _catalogs = new Dictionary<string, IReadOnlyDictionary<string, string>>(StringComparer.OrdinalIgnoreCase)


### PR DESCRIPTION
## Summary
- add diagnostics and health commands that surface telnet session metrics
- instrument TelnetGameServer to track sessions, errors, and command latency via OpenTelemetry + EventCounters
- expose background-process guidance for agents and update localization/tests

## Testing
- dotnet test JinPingMei.sln

Fixes #3