### PR TITLE
Fix CJK/wide-character backspace and add arrow key navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,36 @@ The execution pipeline is under development. Once the initial engine lands, the 
  # - .NET SDK 8.0+
  # - Access token for the chosen LLM provider
 
-# run the telnet host (listens on 127.0.0.1:2323 by default)
+# run the telnet host (listens on 127.0.0.1:2325 by default)
 dotnet run --project src/JinPingMei.Game
 
-# connect from another terminal
-telnet 127.0.0.1 2323
+# connect from another terminal using one of these methods:
+
+# Option 1: Use the provided script for proper terminal handling (RECOMMENDED)
+./connect-raw.sh
+
+# Option 2: Use nc directly (basic, arrow keys may not work properly)
+nc 127.0.0.1 2325
+
+# Option 3: Use telnet (NOT RECOMMENDED - UTF-8 input issues on macOS)
+telnet 127.0.0.1 2325
 ```
+
+### Important Connection Notes for Contributors
+
+The server implements proper telnet negotiation for character-at-a-time mode and server-side echo to support:
+- **CJK character input** - Chinese, Japanese, and Korean characters work correctly
+- **Backspace handling** - Properly deletes wide characters and emoji
+- **Arrow key navigation** - Move cursor left/right within input line
+
+**For best experience, use `./connect-raw.sh`** which puts your terminal in raw mode, allowing:
+- Immediate character transmission (no local line buffering)
+- Server-controlled echo (no double characters)
+- Proper arrow key and special character handling
+
+**Known Issues:**
+- macOS telnet client has broken UTF-8 input support - use `nc` or the connection script instead
+- Without raw mode, arrow keys may display as `^[[D` instead of moving the cursor
 
 While infrastructure code is being authored, you can use this README as a reference for design goals, contribute narrative ideas, or help shape the engine architecture.
 

--- a/connect-raw.sh
+++ b/connect-raw.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Connect to JinPingMei server with proper raw mode for arrow keys
+
+echo "Connecting to JinPingMei server on port 2325..."
+echo "Use Ctrl+C to disconnect"
+echo ""
+
+# Save terminal settings
+SAVED_SETTINGS=$(stty -g)
+
+# Function to restore terminal on exit
+restore_terminal() {
+    stty "$SAVED_SETTINGS"
+    echo -e "\nConnection closed."
+}
+
+# Set up trap to restore terminal
+trap restore_terminal EXIT
+
+# Set terminal to raw mode
+# -echo: don't echo typed characters (server will echo)
+# -icanon: disable canonical mode (send chars immediately)
+# -iexten: disable extended processing
+stty -echo -icanon -iexten
+
+# Connect with nc
+nc 127.0.0.1 2325

--- a/src/JinPingMei.Game/Hosting/TelnetInputProcessor.cs
+++ b/src/JinPingMei.Game/Hosting/TelnetInputProcessor.cs
@@ -1,0 +1,509 @@
+using System;
+using System.Buffers;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using JinPingMei.Game.Hosting.Text;
+
+namespace JinPingMei.Game.Hosting;
+
+internal sealed class TelnetInputProcessor
+{
+    private const byte Backspace = 0x08;
+    private const byte Delete = 0x7F;
+    private const byte CarriageReturn = 0x0D;
+    private const byte LineFeed = 0x0A;
+    private const byte Iac = 0xFF;
+    private const byte Do = 0xFD;
+    private const byte Dont = 0xFE;
+    private const byte Will = 0xFB;
+    private const byte Wont = 0xFC;
+    private const byte SubNegotiation = 0xFA;
+    private const byte EndSubNegotiation = 0xF0;
+    private const byte EchoOption = 0x01;
+    private const byte SuppressGoAhead = 0x03;
+    private const byte LineMode = 0x22;
+
+    private readonly StreamWriter _writer;
+    private readonly Stream _stream;
+    private readonly Decoder _decoder = Encoding.UTF8.GetDecoder();
+    private readonly GraphemeBuffer _buffer = new();
+
+    private TelnetCommandState _telnetState = TelnetCommandState.Data;
+    private byte _pendingCommand;
+    private bool _pendingCarriageReturn;
+    private readonly bool _echoInput;
+    private AnsiEscapeState _ansiState = AnsiEscapeState.None;
+    private readonly List<byte> _escapeBuffer = new();
+
+    public TelnetInputProcessor(Stream stream, StreamWriter writer, bool echoInput = true)
+    {
+        _stream = stream ?? throw new ArgumentNullException(nameof(stream));
+        _writer = writer ?? throw new ArgumentNullException(nameof(writer));
+        _echoInput = echoInput;
+    }
+
+    public async Task InitializeNegotiationAsync(CancellationToken cancellationToken)
+    {
+        // Tell client we WILL do server-side echo
+        await SendCommandAsync(Will, EchoOption, cancellationToken).ConfigureAwait(false);
+        // Tell client we WILL suppress go-ahead
+        await SendCommandAsync(Will, SuppressGoAhead, cancellationToken).ConfigureAwait(false);
+        // Tell client we WON'T do linemode (force character mode)
+        await SendCommandAsync(Wont, LineMode, cancellationToken).ConfigureAwait(false);
+        // Request client to suppress go-ahead
+        await SendCommandAsync(Do, SuppressGoAhead, cancellationToken).ConfigureAwait(false);
+        // Request client not to echo locally
+        await SendCommandAsync(Dont, EchoOption, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<string?> ReadLineAsync(CancellationToken cancellationToken)
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(1024);
+        try
+        {
+            while (true)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var read = await _stream.ReadAsync(buffer.AsMemory(0, buffer.Length), cancellationToken).ConfigureAwait(false);
+                if (read == 0)
+                {
+                    return _buffer.TryDrain(out var partial) ? partial : null;
+                }
+
+                for (var i = 0; i < read; i++)
+                {
+                    var value = buffer[i];
+
+                    if (_telnetState != TelnetCommandState.Data)
+                    {
+                        await HandleTelnetCommandByteAsync(value, cancellationToken).ConfigureAwait(false);
+                        continue;
+                    }
+
+                    if (value == Iac)
+                    {
+                        _telnetState = TelnetCommandState.Command;
+                        continue;
+                    }
+
+                    // Check for ESC character (start of ANSI escape sequence)
+                    if (value == 0x1B)
+                    {
+                        _ansiState = AnsiEscapeState.Escape;
+                        _escapeBuffer.Clear();
+                        continue;
+                    }
+
+                    // Handle ANSI escape sequence processing
+                    if (_ansiState != AnsiEscapeState.None)
+                    {
+                        await HandleAnsiEscapeByteAsync(value).ConfigureAwait(false);
+                        continue;
+                    }
+
+                    if (value == Backspace || value == Delete)
+                    {
+                        await HandleBackspaceAsync().ConfigureAwait(false);
+                        continue;
+                    }
+
+                    if (value == CarriageReturn)
+                    {
+                        _pendingCarriageReturn = true;
+                        return await CompleteLineAsync().ConfigureAwait(false);
+                    }
+
+                    if (value == LineFeed)
+                    {
+                        if (_pendingCarriageReturn)
+                        {
+                            _pendingCarriageReturn = false;
+                            continue;
+                        }
+
+                        return await CompleteLineAsync().ConfigureAwait(false);
+                    }
+
+                    await DecodeAndAppendAsync(value, cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    private async ValueTask DecodeAndAppendAsync(byte value, CancellationToken cancellationToken)
+    {
+        Span<byte> input = stackalloc byte[1] { value };
+        Span<char> chars = stackalloc char[2];
+        var count = _decoder.GetChars(input, chars, flush: false);
+        if (count == 0)
+        {
+            return;
+        }
+
+        StringBuilder? echoBuilder = _echoInput ? new StringBuilder() : null;
+        var runeBuffer = _echoInput ? new char[2] : Array.Empty<char>();
+        var remaining = chars[..count];
+        while (!remaining.IsEmpty)
+        {
+            var status = Rune.DecodeFromUtf16(remaining, out var rune, out var consumed);
+            if (status != OperationStatus.Done)
+            {
+                break;
+            }
+
+            remaining = remaining[consumed..];
+
+            // Check if we're inserting in the middle
+            var isInsertingInMiddle = _buffer.CursorPosition < _buffer.Length;
+
+            // Get text after cursor before insertion (if any)
+            string? textAfterCursor = null;
+            int widthAfterCursor = 0;
+            if (isInsertingInMiddle && _echoInput)
+            {
+                textAfterCursor = _buffer.GetTextAfterCursor();
+                widthAfterCursor = _buffer.GetDisplayWidthAfterCursor();
+            }
+
+            _buffer.Append(rune);
+
+            if (echoBuilder is not null)
+            {
+                var written = rune.EncodeToUtf16(runeBuffer);
+                echoBuilder.Append(runeBuffer.AsSpan(0, written));
+
+                // If inserting in middle, we need to redraw the text after cursor
+                if (isInsertingInMiddle && !string.IsNullOrEmpty(textAfterCursor))
+                {
+                    // Add the text that comes after
+                    echoBuilder.Append(textAfterCursor);
+                    // Add spaces to clear any leftover characters
+                    echoBuilder.Append(' ', 2);
+                    // Move cursor back to where it should be
+                    if (widthAfterCursor > 0)
+                    {
+                        echoBuilder.Append(new string('\b', widthAfterCursor + 2));
+                    }
+                }
+            }
+        }
+
+        if (echoBuilder is not null && echoBuilder.Length > 0)
+        {
+            await _writer.WriteAsync(echoBuilder.ToString()).ConfigureAwait(false);
+        }
+    }
+
+    private async Task<string?> CompleteLineAsync()
+    {
+        if (_echoInput)
+        {
+            await _writer.WriteAsync("\r\n").ConfigureAwait(false);
+        }
+
+        _decoder.Reset();
+        _pendingCarriageReturn = false;
+        if (!_buffer.TryDrain(out var line))
+        {
+            return string.Empty;
+        }
+
+        return line;
+    }
+
+    private async Task HandleBackspaceAsync()
+    {
+        // Check if we're deleting in the middle
+        var isMiddleDeletion = _buffer.CursorPosition < _buffer.Length;
+
+        // Get text after cursor before deletion
+        string? textAfterCursor = null;
+        int widthAfterCursor = 0;
+        if (isMiddleDeletion && _echoInput)
+        {
+            textAfterCursor = _buffer.GetTextAfterCursor();
+            widthAfterCursor = _buffer.GetDisplayWidthAfterCursor();
+        }
+
+        if (!_buffer.TryBackspace(out var width))
+        {
+            return;
+        }
+
+        if (width <= 0)
+        {
+            width = 1;
+        }
+
+        if (!_echoInput)
+        {
+            return;
+        }
+
+        if (isMiddleDeletion && !string.IsNullOrEmpty(textAfterCursor))
+        {
+            // Move cursor back by the width of deleted character
+            await _writer.WriteAsync(new string('\b', width)).ConfigureAwait(false);
+            // Write the text that was after the cursor
+            await _writer.WriteAsync(textAfterCursor).ConfigureAwait(false);
+            // Write spaces to clear any leftover characters
+            await _writer.WriteAsync(new string(' ', width)).ConfigureAwait(false);
+            // Move cursor back to the correct position
+            await _writer.WriteAsync(new string('\b', widthAfterCursor + width)).ConfigureAwait(false);
+        }
+        else
+        {
+            // Standard backspace at end of line
+            var sequence = EraseSequences.ForWidth(width);
+            await _writer.WriteAsync(sequence).ConfigureAwait(false);
+        }
+    }
+
+    private async ValueTask HandleTelnetCommandByteAsync(byte value, CancellationToken cancellationToken)
+    {
+        switch (_telnetState)
+        {
+            case TelnetCommandState.Command:
+                switch (value)
+                {
+                    case Iac:
+                        await DecodeAndAppendAsync(value, cancellationToken).ConfigureAwait(false);
+                        _telnetState = TelnetCommandState.Data;
+                        break;
+                    case Do:
+                    case Dont:
+                    case Will:
+                    case Wont:
+                        _pendingCommand = value;
+                        _telnetState = TelnetCommandState.Option;
+                        break;
+                    case SubNegotiation:
+                        _telnetState = TelnetCommandState.SubNegotiation;
+                        break;
+                    default:
+                        _telnetState = TelnetCommandState.Data;
+                        break;
+                }
+                break;
+            case TelnetCommandState.Option:
+                await RespondToOptionAsync(value, cancellationToken).ConfigureAwait(false);
+                _telnetState = TelnetCommandState.Data;
+                break;
+            case TelnetCommandState.SubNegotiation:
+                if (value == Iac)
+                {
+                    _telnetState = TelnetCommandState.SubNegotiationEnd;
+                }
+                break;
+            case TelnetCommandState.SubNegotiationEnd:
+                _telnetState = value == EndSubNegotiation
+                    ? TelnetCommandState.Data
+                    : TelnetCommandState.SubNegotiation;
+                break;
+        }
+    }
+
+    private async ValueTask RespondToOptionAsync(byte option, CancellationToken cancellationToken)
+    {
+        switch (_pendingCommand)
+        {
+            case Do:
+                // Accept ECHO and SUPPRESS_GO_AHEAD requests
+                if (option == EchoOption || option == SuppressGoAhead)
+                {
+                    await SendCommandAsync(Will, option, cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    await SendCommandAsync(Wont, option, cancellationToken).ConfigureAwait(false);
+                }
+                break;
+            case Dont:
+                await SendCommandAsync(Wont, option, cancellationToken).ConfigureAwait(false);
+                break;
+            case Will:
+                // Accept client's SUPPRESS_GO_AHEAD offer
+                if (option == SuppressGoAhead)
+                {
+                    await SendCommandAsync(Do, option, cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    await SendCommandAsync(Dont, option, cancellationToken).ConfigureAwait(false);
+                }
+                break;
+            case Wont:
+                break;
+        }
+    }
+
+    private ValueTask SendCommandAsync(byte command, byte option, CancellationToken cancellationToken)
+    {
+        var payload = new byte[] { Iac, command, option };
+        return _stream.WriteAsync(payload, cancellationToken);
+    }
+
+    private async Task HandleAnsiEscapeByteAsync(byte value)
+    {
+        switch (_ansiState)
+        {
+            case AnsiEscapeState.Escape:
+                if (value == 0x5B) // '[' character
+                {
+                    _ansiState = AnsiEscapeState.Bracket;
+                    _escapeBuffer.Add(value);
+                }
+                else
+                {
+                    // Not a recognized escape sequence, reset
+                    _ansiState = AnsiEscapeState.None;
+                    _escapeBuffer.Clear();
+                }
+                break;
+
+            case AnsiEscapeState.Bracket:
+            case AnsiEscapeState.Collecting:
+                _escapeBuffer.Add(value);
+
+                // Check if this completes a recognized sequence
+                if (value >= 0x40 && value <= 0x7E) // Final byte range
+                {
+                    await ProcessAnsiSequenceAsync().ConfigureAwait(false);
+                    _ansiState = AnsiEscapeState.None;
+                    _escapeBuffer.Clear();
+                }
+                else if (_escapeBuffer.Count > 10) // Safety limit
+                {
+                    // Too long, probably not a valid sequence
+                    _ansiState = AnsiEscapeState.None;
+                    _escapeBuffer.Clear();
+                }
+                else
+                {
+                    _ansiState = AnsiEscapeState.Collecting;
+                }
+                break;
+        }
+    }
+
+    private async Task ProcessAnsiSequenceAsync()
+    {
+        if (_escapeBuffer.Count == 0) return;
+
+        var finalByte = _escapeBuffer[^1];
+
+        // Handle arrow keys: ESC [ A/B/C/D
+        if (_escapeBuffer.Count == 2 && _escapeBuffer[0] == 0x5B)
+        {
+            switch (finalByte)
+            {
+                case 0x41: // Up arrow - move to start of line
+                    await HandleHomeKeyAsync().ConfigureAwait(false);
+                    break;
+                case 0x42: // Down arrow - move to end of line
+                    await HandleEndKeyAsync().ConfigureAwait(false);
+                    break;
+                case 0x43: // Right arrow
+                    await HandleRightArrowAsync().ConfigureAwait(false);
+                    break;
+                case 0x44: // Left arrow
+                    await HandleLeftArrowAsync().ConfigureAwait(false);
+                    break;
+            }
+        }
+        // Handle Home/End: ESC [ H, ESC [ F, ESC [ 1 ~, ESC [ 4 ~
+        else if (_escapeBuffer[0] == 0x5B)
+        {
+            if (finalByte == 0x48 || (_escapeBuffer.Count == 3 && _escapeBuffer[1] == 0x31 && finalByte == 0x7E))
+            {
+                await HandleHomeKeyAsync().ConfigureAwait(false);
+            }
+            else if (finalByte == 0x46 || (_escapeBuffer.Count == 3 && _escapeBuffer[1] == 0x34 && finalByte == 0x7E))
+            {
+                await HandleEndKeyAsync().ConfigureAwait(false);
+            }
+        }
+    }
+
+    private async Task HandleLeftArrowAsync()
+    {
+        if (_buffer.MoveCursorLeft(out var width))
+        {
+            if (_echoInput && width > 0)
+            {
+                // Move cursor left by width positions
+                var sequence = new string('\b', width);
+                await _writer.WriteAsync(sequence).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private async Task HandleRightArrowAsync()
+    {
+        if (_buffer.MoveCursorRight(out var width))
+        {
+            if (_echoInput && width > 0)
+            {
+                // Move cursor right by width positions using ESC[C
+                var sequence = $"\x1b[{width}C";
+                await _writer.WriteAsync(sequence).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private async Task HandleHomeKeyAsync()
+    {
+        var totalWidth = 0;
+        while (_buffer.MoveCursorLeft(out var width))
+        {
+            totalWidth += width;
+        }
+
+        if (_echoInput && totalWidth > 0)
+        {
+            // Move cursor to start
+            var sequence = new string('\b', totalWidth);
+            await _writer.WriteAsync(sequence).ConfigureAwait(false);
+        }
+    }
+
+    private async Task HandleEndKeyAsync()
+    {
+        var totalWidth = 0;
+        while (_buffer.MoveCursorRight(out var width))
+        {
+            totalWidth += width;
+        }
+
+        if (_echoInput && totalWidth > 0)
+        {
+            // Move cursor to end
+            var sequence = $"\x1b[{totalWidth}C";
+            await _writer.WriteAsync(sequence).ConfigureAwait(false);
+        }
+    }
+
+    private enum TelnetCommandState
+    {
+        Data,
+        Command,
+        Option,
+        SubNegotiation,
+        SubNegotiationEnd
+    }
+
+    private enum AnsiEscapeState
+    {
+        None,
+        Escape,
+        Bracket,
+        Collecting
+    }
+
+}

--- a/src/JinPingMei.Game/Hosting/Text/EraseSequences.cs
+++ b/src/JinPingMei.Game/Hosting/Text/EraseSequences.cs
@@ -1,0 +1,14 @@
+namespace JinPingMei.Game.Hosting.Text;
+
+internal static class EraseSequences
+{
+    public static string ForWidth(int width)
+    {
+        if (width <= 0)
+        {
+            width = 1;
+        }
+
+        return new string('\b', width) + new string(' ', width) + new string('\b', width);
+    }
+}

--- a/src/JinPingMei.Game/Hosting/Text/GraphemeBuffer.cs
+++ b/src/JinPingMei.Game/Hosting/Text/GraphemeBuffer.cs
@@ -1,0 +1,302 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+
+namespace JinPingMei.Game.Hosting.Text;
+
+internal sealed class GraphemeBuffer
+{
+    private static readonly (int Start, int End)[] WideRanges =
+    {
+        (0x1100, 0x115F),
+        (0x2329, 0x232A),
+        (0x2E80, 0xA4CF),
+        (0xAC00, 0xD7A3),
+        (0xF900, 0xFAFF),
+        (0xFE10, 0xFE6F),
+        (0xFF00, 0xFF60),
+        (0xFFE0, 0xFFE6),
+        (0x1F300, 0x1F64F),
+        (0x1F900, 0x1F9FF),
+        (0x1FA70, 0x1FAFF)
+    };
+
+    private readonly List<GraphemeCluster> _clusters = new();
+    private bool _pendingJoin;
+    private int _cursorPosition; // Position in clusters
+
+    public int CursorPosition => _cursorPosition;
+    public int Length => _clusters.Count;
+
+    public void Append(Rune rune)
+    {
+        // Insert at cursor position
+        if (_cursorPosition < _clusters.Count)
+        {
+            // Check if we should combine with the cluster before cursor
+            if (_cursorPosition > 0 && ShouldCombine(rune))
+            {
+                _clusters[_cursorPosition - 1].Add(rune);
+                return;
+            }
+
+            var newCluster = new GraphemeCluster();
+            newCluster.Add(rune);
+            _clusters.Insert(_cursorPosition, newCluster);
+            _cursorPosition++;
+            _pendingJoin = rune.Value == 0x200D;
+            return;
+        }
+
+        // Append at the end (cursor at end)
+        if (_clusters.Count > 0 && ShouldCombine(rune))
+        {
+            _clusters[^1].Add(rune);
+            return;
+        }
+
+        var endCluster = new GraphemeCluster();
+        endCluster.Add(rune);
+        _clusters.Add(endCluster);
+        _cursorPosition++;
+        _pendingJoin = rune.Value == 0x200D;
+    }
+
+    public bool MoveCursorLeft(out int displayDelta)
+    {
+        if (_cursorPosition > 0)
+        {
+            _cursorPosition--;
+            displayDelta = _clusters[_cursorPosition].DisplayWidth;
+            return true;
+        }
+        displayDelta = 0;
+        return false;
+    }
+
+    public bool MoveCursorRight(out int displayDelta)
+    {
+        if (_cursorPosition < _clusters.Count)
+        {
+            displayDelta = _clusters[_cursorPosition].DisplayWidth;
+            _cursorPosition++;
+            return true;
+        }
+        displayDelta = 0;
+        return false;
+    }
+
+    public void MoveCursorToStart()
+    {
+        _cursorPosition = 0;
+    }
+
+    public void MoveCursorToEnd()
+    {
+        _cursorPosition = _clusters.Count;
+    }
+
+    public string GetTextAfterCursor()
+    {
+        if (_cursorPosition >= _clusters.Count)
+        {
+            return string.Empty;
+        }
+
+        var remainingClusters = _clusters.Skip(_cursorPosition).ToArray();
+        var totalLength = remainingClusters.Sum(c => c.Utf16Length);
+
+        if (totalLength == 0)
+        {
+            return string.Empty;
+        }
+
+        return string.Create(totalLength, remainingClusters, static (span, clusters) =>
+        {
+            var index = 0;
+            foreach (var cluster in clusters)
+            {
+                foreach (var rune in cluster.Runes)
+                {
+                    index += rune.EncodeToUtf16(span[index..]);
+                }
+            }
+        });
+    }
+
+    public int GetDisplayWidthAfterCursor()
+    {
+        if (_cursorPosition >= _clusters.Count)
+        {
+            return 0;
+        }
+
+        return _clusters.Skip(_cursorPosition).Sum(c => c.DisplayWidth);
+    }
+
+    public bool TryBackspace(out int width)
+    {
+        if (_cursorPosition == 0)
+        {
+            width = 0;
+            _pendingJoin = false;
+            return false;
+        }
+
+        var removeIndex = _cursorPosition - 1;
+        var removed = _clusters[removeIndex];
+        _clusters.RemoveAt(removeIndex);
+        _cursorPosition--;
+        _pendingJoin = false;
+        width = removed.DisplayWidth;
+        return true;
+    }
+
+    public bool TryDelete(out int width)
+    {
+        if (_cursorPosition >= _clusters.Count)
+        {
+            width = 0;
+            return false;
+        }
+
+        var removed = _clusters[_cursorPosition];
+        _clusters.RemoveAt(_cursorPosition);
+        width = removed.DisplayWidth;
+        return true;
+    }
+
+    public bool TryDrain(out string result)
+    {
+        if (_clusters.Count == 0)
+        {
+            _pendingJoin = false;
+            result = string.Empty;
+            return false;
+        }
+
+        var totalLength = 0;
+        foreach (var cluster in _clusters)
+        {
+            totalLength += cluster.Utf16Length;
+        }
+
+        var snapshot = _clusters.ToArray();
+        result = string.Create(totalLength, snapshot, static (span, clusters) =>
+        {
+            var index = 0;
+            foreach (var cluster in clusters)
+            {
+                foreach (var rune in cluster.Runes)
+                {
+                    index += rune.EncodeToUtf16(span[index..]);
+                }
+            }
+        });
+
+        _clusters.Clear();
+        _pendingJoin = false;
+        _cursorPosition = 0;
+        return true;
+    }
+
+    private bool ShouldCombine(Rune rune)
+    {
+        if (_pendingJoin)
+        {
+            _pendingJoin = rune.Value == 0x200D;
+            return true;
+        }
+
+        var category = Rune.GetUnicodeCategory(rune);
+        switch (category)
+        {
+            case UnicodeCategory.NonSpacingMark:
+            case UnicodeCategory.SpacingCombiningMark:
+            case UnicodeCategory.EnclosingMark:
+                return true;
+            case UnicodeCategory.Format:
+                if (rune.Value == 0x200D)
+                {
+                    _pendingJoin = true;
+                }
+                return true;
+        }
+
+        if (rune.Value is >= 0xFE00 and <= 0xFE0F)
+        {
+            return true;
+        }
+
+        if (rune.Value is >= 0xE0100 and <= 0xE01EF)
+        {
+            return true;
+        }
+
+        if (rune.Value is >= 0x1F3FB and <= 0x1F3FF)
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static int GetDisplayWidth(Rune rune)
+    {
+        var category = Rune.GetUnicodeCategory(rune);
+        switch (category)
+        {
+            case UnicodeCategory.NonSpacingMark:
+            case UnicodeCategory.SpacingCombiningMark:
+            case UnicodeCategory.EnclosingMark:
+            case UnicodeCategory.Format:
+            case UnicodeCategory.Control:
+                return 0;
+        }
+
+        var value = rune.Value;
+
+        if (value is >= 0x1F3FB and <= 0x1F3FF)
+        {
+            return 0;
+        }
+        foreach (var (start, end) in WideRanges)
+        {
+            if (value >= start && value <= end)
+            {
+                return 2;
+            }
+        }
+
+        return 1;
+    }
+
+    private sealed class GraphemeCluster
+    {
+        public List<Rune> Runes { get; } = new();
+        public int DisplayWidth { get; private set; }
+        public int Utf16Length { get; private set; }
+
+        public void Add(Rune rune)
+        {
+            Runes.Add(rune);
+            Utf16Length += rune.Utf16SequenceLength;
+
+            // For the first rune, use its display width
+            // For subsequent runes (combining marks, modifiers), only add non-zero width
+            var width = GetDisplayWidth(rune);
+            if (Runes.Count == 1)
+            {
+                DisplayWidth = width;
+            }
+            else if (width > 0)
+            {
+                // Only override display width if this is a non-combining character with width
+                // This handles emoji sequences properly
+                DisplayWidth = Math.Max(DisplayWidth, width);
+            }
+        }
+    }
+}

--- a/tests/JinPingMei.Engine.Tests/GraphemeBufferTests.cs
+++ b/tests/JinPingMei.Engine.Tests/GraphemeBufferTests.cs
@@ -1,0 +1,122 @@
+using System.Text;
+using JinPingMei.Game.Hosting.Text;
+using Xunit;
+
+namespace JinPingMei.Engine.Tests;
+
+public class GraphemeBufferTests
+{
+    [Fact]
+    public void Backspace_CjkCharacter_UsesDoubleWidth()
+    {
+        var buffer = new GraphemeBuffer();
+        buffer.Append(new Rune('中'));
+
+        var removed = buffer.TryBackspace(out var width);
+
+        Assert.True(removed);
+        Assert.Equal(2, width);
+    }
+
+    [Fact]
+    public void Backspace_EmojiSequence_RemovesAsSingleCluster()
+    {
+        var buffer = new GraphemeBuffer();
+        foreach (var rune in "👍🏽".EnumerateRunes())
+        {
+            buffer.Append(rune);
+        }
+
+        var removed = buffer.TryBackspace(out var width);
+
+        Assert.True(removed);
+        Assert.Equal(2, width);
+    }
+
+    [Fact]
+    public void Backspace_CombiningMarkSequence_TreatedAsWidthOne()
+    {
+        var buffer = new GraphemeBuffer();
+        foreach (var rune in "a\u0301".EnumerateRunes())
+        {
+            buffer.Append(rune);
+        }
+
+        var removed = buffer.TryBackspace(out var width);
+
+        Assert.True(removed);
+        Assert.Equal(1, width);
+    }
+
+    [Fact]
+    public void Drain_ReturnsFullTextAndClears()
+    {
+        var buffer = new GraphemeBuffer();
+        foreach (var rune in "中文".EnumerateRunes())
+        {
+            buffer.Append(rune);
+        }
+
+        var drained = buffer.TryDrain(out var text);
+
+        Assert.True(drained);
+        Assert.Equal("中文", text);
+        Assert.False(buffer.TryDrain(out var empty));
+        Assert.Equal(string.Empty, empty);
+    }
+
+    [Fact]
+    public void Backspace_MultipleCjkCharacters_RemovesOneAtATime()
+    {
+        var buffer = new GraphemeBuffer();
+        foreach (var rune in "中文".EnumerateRunes())
+        {
+            buffer.Append(rune);
+        }
+
+        var removed1 = buffer.TryBackspace(out var width1);
+        Assert.True(removed1);
+        Assert.Equal(2, width1);
+
+        var drained = buffer.TryDrain(out var remaining);
+        Assert.True(drained);
+        Assert.Equal("中", remaining);
+    }
+
+    [Theory]
+    [InlineData('中', 2)]
+    [InlineData('文', 2)]
+    [InlineData('あ', 2)]
+    [InlineData('ア', 2)]
+    [InlineData('가', 2)]
+    [InlineData('a', 1)]
+    [InlineData(' ', 1)]
+    public void GetDisplayWidth_VariousCharacters_ReturnsCorrectWidth(char ch, int expectedWidth)
+    {
+        var buffer = new GraphemeBuffer();
+        buffer.Append(new Rune(ch));
+
+        var removed = buffer.TryBackspace(out var width);
+
+        Assert.True(removed);
+        Assert.Equal(expectedWidth, width);
+    }
+
+    [Fact]
+    public void Backspace_EmojiWithSkinTone_RemovesCompleteSequence()
+    {
+        var buffer = new GraphemeBuffer();
+        foreach (var rune in "👍🏽".EnumerateRunes())
+        {
+            buffer.Append(rune);
+        }
+
+        var removed = buffer.TryBackspace(out var width);
+        Assert.True(removed);
+        Assert.Equal(2, width);
+
+        var drained = buffer.TryDrain(out var text);
+        Assert.False(drained);
+        Assert.Equal(string.Empty, text);
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes #18 - Backspace now correctly deletes CJK and wide characters
- Adds arrow key navigation for cursor movement within input line
- Implements proper text insertion/deletion at any cursor position

## Implementation Details

### Unicode Handling
- Created `GraphemeBuffer` class for proper Unicode grapheme cluster handling
- Correctly calculates display width for CJK characters (2 columns)
- Handles emoji sequences with modifiers (👍🏽)
- Supports combining marks (á, é, ñ)

### Telnet Improvements
- Added telnet negotiation for character-at-a-time mode
- Server-side echo control (IAC WILL ECHO)
- Suppress go-ahead for smoother communication
- ANSI escape sequence parsing for arrow keys

### Terminal Support
- Created `connect-raw.sh` script for proper terminal raw mode
- Documents connection methods in README
- Handles macOS telnet UTF-8 limitations

## Test Coverage
- Comprehensive unit tests for `GraphemeBuffer`
- Tests for CJK character width calculation
- Tests for emoji and combining mark handling
- Manual testing with various terminal emulators

## Testing Instructions
1. Run the server: `dotnet run --project src/JinPingMei.Game`
2. Connect using: `./connect-raw.sh`
3. Test CJK input: Type `中文` and use backspace
4. Test arrow keys: Type text and use left/right arrows
5. Test insertion: Move cursor to middle and type
6. Test deletion: Move cursor to middle and backspace

## Screenshots/Demo
The fix ensures proper handling of:
- ✅ CJK characters (中文, 日本語, 한글)
- ✅ Arrow key navigation (← → ↑ ↓)
- ✅ Text insertion at cursor position
- ✅ Backspace with proper text reflow

🤖 Generated with [Claude Code](https://claude.ai/code)